### PR TITLE
Cleanup the setup progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,12 @@ Simple CLI for tracking work hours into Google calendar.
 - Download the latest `goc` file from the **release** page or clone this repo and build it yourself
 - Make sure `goc` is executable, if not run: `chmod +x goc`
 - Move the `goc` file into `/usr/local/bin` or any other folder that is in your `$PATH`
-- Setup and download the Google credentials.json file [here](https://console.cloud.google.com/apis/credentials)
-  - Create a new project
-  - Setup OAuth consent screen
-    - Fill out all required fields
-    - For scopes, add `calendarlist.readonly` and `calendar.events`
-    - For test users, add your own email
-  - Click on credentials and create credentials then select OAuth client ID
-  - Set application type to Desktop app and follow the steps
-  - Choose download JSON after creating the credential
-  - Rename the file you downloaded to `credentials.json`
-  - Move this file into `$HOME/.goc_cli` (need to create this folder yourself)
-- Reset(close/reopen) terminal window for changes to take effect
+- Run `goc setup` to configure the calendar.
 - Run `goc` to see help and usage, and `goc help COMMAND` to see command info
 
 ## Setup (Other)
 
-If you want to use this on Max and Windows, you need to make some changes.
+If you want to use this on Mac and Windows, you need to make some changes.
 This includes, but may not be limited to the following:
 
 - You need to build the executable on your own, the one in the **release** page will not work

--- a/file.go
+++ b/file.go
@@ -6,11 +6,16 @@ import (
 	"os"
 )
 
-var SHARED_PATH = os.Getenv("HOME") + "/.goc_cli/"
+var dirname, err = os.UserConfigDir()
+
+var SHARED_PATH = dirname + "/goc_cli/"
 var FILE_NAME = "data.json"
 
 func readFile() *FileData {
 	path := SHARED_PATH + FILE_NAME
+
+	createDataFileIfNotExists(path)
+
 	f, err := os.Open(path)
 	if err != nil {
 		log.Fatalf("Unable to open file: %v", err)
@@ -26,6 +31,9 @@ func readFile() *FileData {
 
 func writeToFile(data *FileData) {
 	path := SHARED_PATH + FILE_NAME
+
+	createDataFileIfNotExists(path)
+
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		log.Fatalf("Unable to open file: %v", err)
@@ -36,3 +44,16 @@ func writeToFile(data *FileData) {
 		log.Fatalf("Unable to write to file: %v", err)
 	}
 }
+
+func createDataFileIfNotExists(path string) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		data := []byte("{}")
+		err := os.WriteFile(path, data, 0644)
+
+		if (err != nil) {
+			log.Fatal(err)
+		}
+	}
+}
+
+


### PR DESCRIPTION
> Warning: First time writing Go 🤕 

### Breaking
- Now uses XDG config dir (preferred location for config)
  - Usually `$HOME/.config/goc_cli`

### Other
1. Move the setup instructions into `goc setup`
2. Auto-create the config directory
3. Auto-create data.json (got error when this file didn't exist is setup)