### PR TITLE
Support status as oneline

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/urfave/cli"
 )
@@ -206,6 +207,24 @@ func TaskStatus(c *cli.Context) {
 		os.Exit(0)
 	}
 
+	start, err := time.Parse(time.RFC3339, data.CurrentTask.Start)
+
+	if (err != nil) {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	duration := time.Since(start).Round(time.Second)
+
+	if (c.Bool("oneline")) {
+		fmt.Printf("%s (%v)", data.CurrentTask.Name, duration)
+
+		os.Exit(0)
+	}
+
 	t := formatTimeString(data.CurrentTask.Start)
-	fmt.Println("Task status:\n------------\nNavn: " + data.CurrentTask.Name + "\nStart: " + t)
+	fmt.Println("Task status:\n------------")
+	fmt.Println("Name:", data.CurrentTask.Name)
+	fmt.Println("Start:", t)
+	fmt.Println("Duration:", duration)
 }

--- a/cmd/goc.go
+++ b/cmd/goc.go
@@ -104,6 +104,12 @@ func commands() {
 			Aliases: []string{"st"},
 			Usage:   "Get current task status",
 			Action:  goc.TaskStatus,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "oneline",
+					Usage: "List status in oneline format",
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Can be used in terminal 

![image](https://user-images.githubusercontent.com/41789/198416991-86488ee7-32ee-448d-aa16-300a5874b409.png)

Or in status-bar :) 
![image](https://user-images.githubusercontent.com/41789/198420153-967a3b18-4651-451d-b1c0-5c93e7ebf39f.png)



Also added duration to normal status
![image](https://user-images.githubusercontent.com/41789/198419805-e1856fbf-913a-4799-8cab-1f24b007e748.png)
